### PR TITLE
Support setting a timeout on the mailgun nodemailer transport

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,8 @@ const transport = (options = {}) => {
   const messages = mailgun.client({
     username: 'api',
     key: options.auth.api_key || options.auth.apiKey,
-    url
+    url,
+    timeout: options.timeout,
   }).messages;
 
   const mailgunSend = mail => messages.create(options.auth.domain || "", mail);

--- a/src/index.js
+++ b/src/index.js
@@ -140,12 +140,14 @@ const transport = (options = {}) => {
     generatedUrl.port = options.port || 443;
     url = generatedUrl.href;
   }
-  const messages = mailgun.client({
+  let mailgun_opts = {
     username: 'api',
     key: options.auth.api_key || options.auth.apiKey,
-    url,
-    timeout: options.timeout,
-  }).messages;
+    url
+  }
+  if (options.timeout)
+    mailgun_opts["timeout"] = options.timeout;
+  const messages = mailgun.client(mailgun_opts).messages;
 
   const mailgunSend = mail => messages.create(options.auth.domain || "", mail);
   return {


### PR DESCRIPTION
Necessary because the default 10 second timeout is sometimes not enough when we include attachments.